### PR TITLE
optimize QChatInterface load

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1677,6 +1677,14 @@ class QChatInterface {
 }
 
 // Initialize the interface when the page loads
-document.addEventListener('DOMContentLoaded', () => {
+console.log('Script loaded, checking DOM state...');
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        console.log('DOM loaded, creating QChatInterface...');
+        new QChatInterface();
+    });
+} else {
+    console.log('DOM already loaded, creating QChatInterface...');
     new QChatInterface();
-});
+}
+


### PR DESCRIPTION
in my enviroment, the chat-contain never shows up. so i ask Q to fix it. here's the summary from Q

> The issue was with the timing of when the script executed versus when the DOM was ready.

Original problem:
• The script was dynamically loaded after the page was already fully loaded
• DOMContentLoaded event only fires once during page load
• Since the DOM was already loaded when the script ran, the event listener was added too late and never triggered
• So new QChatInterface() never executed

The fix:
javascript
if (document.readyState === 'loading') {
    // DOM still loading - wait for DOMContentLoaded
    document.addEventListener('DOMContentLoaded', callback);
} else {
    // DOM already loaded - execute immediately
    callback();
}


This checks document.readyState:
• 'loading' = DOM still loading, so wait for the event
• 'interactive' or 'complete' = DOM ready, so execute immediately

Since your script loads dynamically after the page, the DOM is already in 'complete' state, so it runs the QChatInterface
constructor right away instead of waiting for an event that already happened.